### PR TITLE
Added Support for path params

### DIFF
--- a/src/main/java/com/tls/LiarWire/Utils.java
+++ b/src/main/java/com/tls/LiarWire/Utils.java
@@ -1,0 +1,12 @@
+package com.tls.LiarWire;
+
+public class Utils {
+
+    private Utils() { /*private constructor*/ }
+
+
+    public static String getKeyWithMethodAndEndpoint(String httpMethod, String endpoint){
+        return httpMethod + ":::" + endpoint;
+    }
+
+}

--- a/src/main/java/com/tls/LiarWire/controllers/MockController.java
+++ b/src/main/java/com/tls/LiarWire/controllers/MockController.java
@@ -20,7 +20,7 @@ public class MockController {
     @RequestMapping(value = "/**", method = {RequestMethod.GET, RequestMethod.POST})
     public Mono<ResponseEntity<Object>> executeMock(ServerWebExchange exchange){
         String uri = exchange.getRequest().getURI().getPath();
-        log.debug("Endpoint: {}", uri);
+        log.info("Endpoint: {}", uri);
         return mockService.executeMock(exchange.getRequest());
     }
 

--- a/src/main/java/com/tls/LiarWire/entity/MockApiConfig.java
+++ b/src/main/java/com/tls/LiarWire/entity/MockApiConfig.java
@@ -1,21 +1,34 @@
 package com.tls.LiarWire.entity;
 
+import com.tls.LiarWire.exceptions.InvalidMockConfig;
 import com.tls.LiarWire.dataModels.impl.DelayParameters;
 import com.mongodb.lang.Nullable;
 import com.tls.LiarWire.dataModels.impl.ResponseConfig;
+import com.tls.LiarWire.interfaces.Validatable;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 @Document(collection = "Mock-APIS")
 @Data
-public class MockApiConfig {
+@Slf4j
+public class MockApiConfig implements Validatable {
 
     @Id
+    private ObjectId id;
+
     private String endpoint;
+
+    private String pathMatchingRegex;
+
+    private boolean pathMatchingRequired;
 
     private String httpMethod;
 
@@ -35,4 +48,24 @@ public class MockApiConfig {
     @Nullable
     private DelayParameters delay;
 
+    @Override
+    public void validate() {
+        if(null == endpoint || endpoint.isBlank()){
+            throw new InvalidMockConfig("Endpoint is mandatory");
+        }
+
+        if(pathMatchingRequired && (pathMatchingRegex == null || pathMatchingRegex.isBlank())){
+            throw new InvalidMockConfig("Path matching regex missing for path matchable endpoint: " + endpoint);
+        }
+
+        if(pathMatchingRequired){
+            try{
+                Pattern.compile(pathMatchingRegex);
+            }
+            catch (PatternSyntaxException pse){
+                log.error("Invalid regex: {}, for endpoint: {}", pathMatchingRegex, endpoint);
+                throw new InvalidMockConfig("Invalid regex for endpoint " + endpoint + " : " + pse.getMessage());
+            }
+        }
+    }
 }

--- a/src/main/java/com/tls/LiarWire/exceptions/InvalidMockConfig.java
+++ b/src/main/java/com/tls/LiarWire/exceptions/InvalidMockConfig.java
@@ -1,0 +1,7 @@
+package com.tls.LiarWire.exceptions;
+
+public class InvalidMockConfig extends RuntimeException {
+    public InvalidMockConfig(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/tls/LiarWire/exceptions/MockNotFound.java
+++ b/src/main/java/com/tls/LiarWire/exceptions/MockNotFound.java
@@ -1,0 +1,7 @@
+package com.tls.LiarWire.exceptions;
+
+public class MockNotFound extends RuntimeException {
+    public MockNotFound(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/tls/LiarWire/interfaces/Validatable.java
+++ b/src/main/java/com/tls/LiarWire/interfaces/Validatable.java
@@ -1,0 +1,7 @@
+package com.tls.LiarWire.interfaces;
+
+public interface Validatable {
+
+    void validate() throws RuntimeException;
+
+}

--- a/src/main/java/com/tls/LiarWire/repositories/MockRepository.java
+++ b/src/main/java/com/tls/LiarWire/repositories/MockRepository.java
@@ -1,6 +1,7 @@
 package com.tls.LiarWire.repositories;
 
 import com.tls.LiarWire.entity.MockApiConfig;
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.stereotype.Repository;
@@ -11,5 +12,8 @@ public interface MockRepository extends ReactiveMongoRepository<MockApiConfig, S
 
     @Query("{ '_id': ?0, 'httpMethod': ?1 }")
     Mono<MockApiConfig> findByEndpointAndMethod(String endpoint, String method);
+
+    @Query("{ '_id': ?0 }")
+    Mono<MockApiConfig> findByObjectId(ObjectId id);
 
 }

--- a/src/main/java/com/tls/LiarWire/services/EndpointMatcher.java
+++ b/src/main/java/com/tls/LiarWire/services/EndpointMatcher.java
@@ -1,0 +1,92 @@
+package com.tls.LiarWire.services;
+
+import com.tls.LiarWire.Utils;
+import com.tls.LiarWire.entity.MockApiConfig;
+import com.tls.LiarWire.exceptions.MockNotFound;
+import com.tls.LiarWire.repositories.MockRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.types.ObjectId;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+@Service
+@Slf4j
+public class EndpointMatcher {
+
+    private final MockRepository mockRepository;
+
+    //not making the registries final, might add support to listen to update triggers from mongoDB,
+    // in case configs are updates, so registries can be updated at runtime
+    private Map<Pattern, ObjectId> pathMatchingRegistry;
+
+    private Map<String, ObjectId> directEndpointMatchingRegistry;
+
+    public EndpointMatcher(MockRepository _mockRepository){
+        this.mockRepository = _mockRepository;
+        this.pathMatchingRegistry = new HashMap<>();
+        this.directEndpointMatchingRegistry = new HashMap<>();
+        this.updateRegistries();
+    }
+
+    public void updateRegistries(){
+        Flux<MockApiConfig> apiConfigs = mockRepository.findAll();
+
+        apiConfigs.subscribe(
+                this::addConfigToRegistries,
+                this::errorHandler,
+                this::loadCompleteHandler
+        );
+    }
+
+    public Mono<ObjectId> getIdForPath(String httpMethod, String uri){
+        String apiKey = Utils.getKeyWithMethodAndEndpoint(httpMethod, uri);
+        if(directEndpointMatchingRegistry.containsKey(apiKey)){
+            return Mono.just(directEndpointMatchingRegistry.get(apiKey));
+        }
+        else {
+            for (Map.Entry<Pattern, ObjectId> entry : pathMatchingRegistry.entrySet()) {
+                Pattern pattern = entry.getKey();
+                if (pattern.matcher(uri).matches()) {
+                    return Mono.just(entry.getValue());
+                }
+            }
+        }
+        throw new MockNotFound("Mock not found for " + apiKey);
+    }
+
+    private void addConfigToRegistries(MockApiConfig config){
+        config.validate();
+        if(config.isPathMatchingRequired()){
+            Pattern compiledPattern = Pattern.compile(config.getPathMatchingRegex());
+            if(pathMatchingRegistry.containsKey(compiledPattern)){
+                log.warn("Path already registered for regex {}, not loading endpoint: {}", config.getPathMatchingRegex(), config.getEndpoint());
+            }
+            else{
+                pathMatchingRegistry.put(compiledPattern, config.getId());
+            }
+        } else {
+            String key = Utils.getKeyWithMethodAndEndpoint(config.getHttpMethod() ,config.getEndpoint());
+            if(directEndpointMatchingRegistry.containsKey(key)){
+                log.warn("Duplicate config for endpoint: {}, ignoring this config", config.getEndpoint());
+            }
+            else {
+                directEndpointMatchingRegistry.put(key, config.getId());
+            }
+        }
+    }
+
+    private void errorHandler(Throwable t){
+        log.debug("Error while registering endpoint: {}", t.getMessage(),  t.getCause());
+        log.error("Error occurred while loading config into registry: {}", t.getMessage());
+    }
+
+    private void loadCompleteHandler(){
+        log.info("Loaded configs, path matched endpoints: {}, direct endpoints: {}", pathMatchingRegistry.size(), directEndpointMatchingRegistry.size());
+    }
+
+}

--- a/src/main/resources/SamplePatternMatching.json
+++ b/src/main/resources/SamplePatternMatching.json
@@ -1,0 +1,33 @@
+{
+  "_id": {
+    "$oid": "6910da57f163b31f812ca7ab"
+  },
+  "endpoint": "/test/:id",
+  "pathMatchingRequired": true,
+  "pathMatchingRegex": "^/test/[^/]+$",
+  "httpMethod": "POST",
+  "requestHeaders": {
+    "Authorization": "Bearer abc123",
+    "Accept": "application/json"
+  },
+  "request": "{\"id\":123}",
+  "responsePickerType": "fixedPicker",
+  "responseList": [
+    {
+      "probability": 0.5,
+      "responseHttpStatus": "202",
+      "responseContentType": "json",
+      "responseHeaders": {
+        "Content-Type": "application/json"
+      },
+      "response": "{\"message\":\"success\"}"
+    }
+  ],
+  "delay": {
+    "avg": 0,
+    "p90": 0,
+    "p95": 600,
+    "p99": 700,
+    "type": "avg"
+  }
+}

--- a/target/classes/application.properties
+++ b/target/classes/application.properties
@@ -1,1 +1,10 @@
 spring.application.name=LiarWire
+
+spring.data.mongodb.host=localhost
+spring.data.mongodb.port=27017
+spring.data.mongodb.database=Mocks
+spring.data.mongodb.username=
+spring.data.mongodb.password=
+
+# Optional: Connection URI (overrides host/port/database)
+spring.data.mongodb.uri=mongodb://localhost:27017/


### PR DESCRIPTION
Added the ability to have path params in requests.
Added boolean to indicate if a config requires path matching. Configs are then sorted into 2 different registries to be fetched on api calls.

Also refactored MockServiceImpl to be more in line with reactive code patterns